### PR TITLE
Refactor: Add support SitemapFilter in IndexNow for Python version 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-index-now-for-python==0.1.6
+index-now-for-python==1.0.0

--- a/src/helper/submit.py
+++ b/src/helper/submit.py
@@ -2,7 +2,8 @@ import argparse
 import sys
 
 from index_now import (IndexNowAuthentication, SearchEngineEndpoint,
-                       submit_sitemaps_to_index_now, submit_urls_to_index_now)
+                       SitemapFilter, submit_sitemaps_to_index_now,
+                       submit_urls_to_index_now)
 
 SUCCESS_STATUS_CODES = [200, 202]
 
@@ -152,7 +153,8 @@ if __name__ == "__main__":
 
     if sitemap_locations:
         contains = parse_sitemap_filter_input(input.sitemap_filter)
-        status_code = submit_sitemaps_to_index_now(authentication, sitemap_locations, contains=contains, endpoint=endpoint)
+        filter = SitemapFilter(contains=contains)
+        status_code = submit_sitemaps_to_index_now(authentication, sitemap_locations, filter=filter, endpoint=endpoint)
         if not is_successful_response(status_code):
             print(f"Failed to submit sitemaps. Status code response from {endpoint.name.title()}: {status_code}")
             exit_with_failure()

--- a/test/helper/parse/sitemap_filter_test.py
+++ b/test/helper/parse/sitemap_filter_test.py
@@ -1,5 +1,6 @@
 import pytest
-from index_now.sitemap import filter_urls
+from index_now.sitemap.filter.sitemap import SitemapFilter, filter_sitemap_urls
+from index_now.sitemap.parse import SitemapUrl
 
 from helper.submit import parse_sitemap_filter_input
 
@@ -26,23 +27,26 @@ URLS = [
     "https://example.com/section2/page2",
 ]
 
+SITEMAP_URLS = [SitemapUrl(url) for url in URLS]
+
 
 @pytest.mark.parametrize("sitemap_urls, sitemap_filter_input, expected", [
-    (URLS, "", URLS),
-    (URLS, '', URLS),
-    (URLS, "section1", ["https://example.com/section1/page1"]),
-    (URLS, 'section1', ["https://example.com/section1/page1"]),
-    (URLS, "\'section1\'", ["https://example.com/section1/page1"]),
-    (URLS, '\"section1\"', ["https://example.com/section1/page1"]),
-    (URLS, "section2", ["https://example.com/section2/page1", "https://example.com/section2/page2"]),
-    (URLS, "section3", []),
-    (URLS, r"(section1|section2)", URLS),
-    (URLS, r"(section1|section3)", ["https://example.com/section1/page1"]),
-    (URLS, "r'(section1|section2)'", URLS),
-    (URLS, 'r"(section1|section2)"', URLS),
+    (SITEMAP_URLS, "", URLS),
+    (SITEMAP_URLS, '', URLS),
+    (SITEMAP_URLS, "section1", ["https://example.com/section1/page1"]),
+    (SITEMAP_URLS, 'section1', ["https://example.com/section1/page1"]),
+    (SITEMAP_URLS, "\'section1\'", ["https://example.com/section1/page1"]),
+    (SITEMAP_URLS, '\"section1\"', ["https://example.com/section1/page1"]),
+    (SITEMAP_URLS, "section2", ["https://example.com/section2/page1", "https://example.com/section2/page2"]),
+    (SITEMAP_URLS, "section3", []),
+    (SITEMAP_URLS, r"(section1|section2)", URLS),
+    (SITEMAP_URLS, r"(section1|section3)", ["https://example.com/section1/page1"]),
+    (SITEMAP_URLS, "r'(section1|section2)'", URLS),
+    (SITEMAP_URLS, 'r"(section1|section2)"', URLS),
 ]
 )
-def test_filter_urls(sitemap_urls: list[str], sitemap_filter_input: str, expected: list[str]) -> None:
+def test_filter_urls(sitemap_urls: list[SitemapUrl], sitemap_filter_input: str, expected: list[str]) -> None:
     contains = parse_sitemap_filter_input(sitemap_filter_input)
-    result = filter_urls(sitemap_urls, contains)
+    filter = SitemapFilter(contains=contains)
+    result = filter_sitemap_urls(sitemap_urls, filter)
     assert result == expected


### PR DESCRIPTION
Using the SitemapFilter is a breaking change: https://github.com/jakob-bagterp/index-now-for-python/pull/40